### PR TITLE
Null bug with .isEmptyOrNull on iterables 

### DIFF
--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -20,14 +20,14 @@ import 'equality.dart';
 
 typedef IndexedPredicate<T> = bool Function(int index, T);
 
-extension CollectionsExtensions<T> on Iterable<T> {
+extension CollectionsNullableExtensions<T> on Iterable<T>? {
   /// Returns this Iterable if it's not `null` and the empty list otherwise.
-  Iterable<T> orEmpty() => this;
+  Iterable<T> orEmpty() => this ?? [];
 
   ///Returns `true` if this nullable iterable is either null or empty.
-  bool get isEmptyOrNull => this.isEmpty;
+  bool get isEmptyOrNull => (this?.isEmpty ?? true);
 
-  /// Returns `true` if at least one element matches the given [predicate].
+    /// Returns `true` if at least one element matches the given [predicate].
   bool any(bool predicate(T element)) {
     if (this.isEmptyOrNull) return false;
     for (final element in this.orEmpty()) if (predicate(element)) return true;
@@ -59,7 +59,9 @@ extension CollectionsExtensions<T> on Iterable<T> {
       yield iterators.map((e) => e.current).toList(growable: false);
     }
   }
+}
 
+extension CollectionsExtensions<T> on Iterable<T> {
   ///Sorts elements in the array in-place according to natural sort order of the value returned by specified [selector] function.
   Iterable<T> sortBy<TKey>(
     TKey Function(T) keySelector, {


### PR DESCRIPTION
I ran into an issue after migrating my project to Null Safety, and wondering if it can be corrected.  If I check a list with if(mylist.isEmptyOrNull) it gives an error if the list is null, so it defeats the purpose of using it when we'd otherwise do if(mylist?.isEmpty ?? true) without the extension.
So I monkeyed around in your iterable.dart and figured this out separating these from CollectionsExtensions to extension CollectionsNullableExtensions<T> on Iterable<T>? with the questionmark at the end.. Simple enough.